### PR TITLE
JsonResource

### DIFF
--- a/src/JsonResource.php
+++ b/src/JsonResource.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Baethon\Laravel\Resource;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Illuminate\Http\Resources\Json\JsonResource as BaseResource;
+
+class JsonResource extends BaseResource
+{
+    public function toArray($request)
+    {
+        if (is_null($this->resource)) {
+            return [];
+        }
+
+        if (is_array($this->resource)) {
+            return $this->resource;
+        }
+
+        if ($this->resource instanceof Model) {
+            return array_merge(
+                $this->resource->attributesToArray(),
+                $this->wrapRelations($request)
+            );
+        }
+
+        return $this->resource->toArray();
+    }
+
+    private function wrapRelations($request): array
+    {
+        $getRelations = (function () {
+            return $this->getArrayableRelations();
+        })->bindTo($this->resource, $this->resource);
+
+        $relations = [];
+
+        foreach ($getRelations() as $key => $value) {
+            if ($this->resource::$snakeAttributes) {
+                $key = Str::snake($key);
+            }
+
+            $relations[$key] = resource($value)->toArray($request);
+        }
+
+        return $relations;
+    }
+}

--- a/tests/Integration/JsonResourceTest.php
+++ b/tests/Integration/JsonResourceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Post;
+use App\Models\Tag;
+use Baethon\Laravel\Resource\JsonResource;
+use Baethon\Laravel\Resource\ServiceProvider;
+use Illuminate\Contracts\Support\Arrayable;
+use Orchestra\Testbench\TestCase;
+
+class JsonResourceTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            ServiceProvider::class,
+        ];
+    }
+
+    public function test_it_wraps_relations_using_resource()
+    {
+        $post = new Post(['text' => 'Lorem ipsum']);
+        $post->setRelation('dummy_tags', collect([
+            new Tag(['name' => 'foo']),
+            new Tag(['name' => 'bar']),
+        ]));
+
+        $resource = new JsonResource($post);
+        $expected = [
+            'text' => 'Lorem ipsum',
+            'dummy_tags' => [
+                ['name' => 'foo', 'tag' => true],
+                ['name' => 'bar', 'tag' => true],
+            ],
+        ];
+
+        $this->assertEquals($expected, $resource->resolve());
+    }
+
+    /**
+     * @dataProvider otherResourcesProvider
+     */
+    public function test_it_handles_other_resources($resource, $expected)
+    {
+        $this->assertEquals($expected, (new JsonResource($resource))->resolve());
+    }
+
+    public function otherResourcesProvider()
+    {
+        return [
+            [null, []],
+            [['foo' => 'baz'], ['foo' => 'baz']],
+            [
+                new class () implements Arrayable
+                {
+                    public function toArray()
+                    {
+                        return ['foo' => 'baz'];
+                    }
+                },
+                ['foo' => 'baz']
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## The problem

Laravel API Resource doesn't handle wrapping model relations in their respective API resources

For example: the application defines `PostResource` & `TagResource`. The controller fetches posts with their tags and returns `PostResource` collection. The API resource will convert the model to an array using `Model#toArray()` method which casts all relations in the same way.

Although there's `TagResource`, it won't be used.

## Proposed solution

Add base `JsonResource` class that will pipe all related models through `resource()` factory. This will ensure that each related model will be converted to an array using its API Resource.

## TODO

- [ ] use `JsonRecourse` as a fallback resource in the factory
- [ ] update README